### PR TITLE
Add "bold" and "normal" font weights

### DIFF
--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -41,7 +41,7 @@ now you can add text to your doc:
 ```
 the `Document.add_text` method gets 4 parameters:
 * `text` - the text that will add to the document
-* `font` - the Font wee printing with see Font for more info, by default Arial  12
+* `font` - the Font we are printing with see Font for more info, by default Arial 12 normal
 * `page` - the page's index to print in, by default create new page and add the text to this page
 * `rect` - the rect to print on in (tuple of 4 floats) in the page, by default will be 0.75 inches margin
 now we want to print the document

--- a/pyrinter/document.py
+++ b/pyrinter/document.py
@@ -227,6 +227,8 @@ class Document:
         :return: the width of the text
         """
         root = Tk()  # Needed to estimate the width.
+        if font.weight != "bold": # Make sure we have a valid weight be defaulting to "normal"
+            font.weight = "normal"
         font_var = TkFont(family=font.font_name, size=font.height, weight=font.weight)
         width = font_var.measure(text) / 105
         root.destroy()  # Destroy the created window

--- a/pyrinter/document.py
+++ b/pyrinter/document.py
@@ -1,17 +1,19 @@
+from dataclasses import dataclass
 from enum import Enum
 from tkinter import Tk
 from tkinter.font import Font as TkFont
-from collections import namedtuple
-from typing import Tuple, Generator, Optional, Union
+from typing import Literal, Tuple, Generator, Optional, Union
 from PIL import Image
 
-
-class Font(namedtuple("Font", ("font_name", "height", "weight"))):
+@dataclass
+class Font:
     """
     class to represent font properties (font name, height and weight)
-
-    weight can be either "normal" or "bold"
     """
+
+    font_name: str
+    height: int
+    weight: Literal["normal", "bold"] = "normal"
 
 
 class Align(Enum):
@@ -227,8 +229,6 @@ class Document:
         :return: the width of the text
         """
         root = Tk()  # Needed to estimate the width.
-        if font.weight != "bold": # Make sure we have a valid weight be defaulting to "normal"
-            font.weight = "normal"
         font_var = TkFont(family=font.font_name, size=font.height, weight=font.weight)
         width = font_var.measure(text) / 105
         root.destroy()  # Destroy the created window

--- a/pyrinter/document.py
+++ b/pyrinter/document.py
@@ -6,9 +6,11 @@ from typing import Tuple, Generator, Optional, Union
 from PIL import Image
 
 
-class Font(namedtuple("Font", ("font_name", "height"))):
+class Font(namedtuple("Font", ("font_name", "height", "weight"))):
     """
-    class to represent font properties (font name and height)
+    class to represent font properties (font name, height and weight)
+
+    weight can be either "normal" or "bold"
     """
 
 
@@ -57,7 +59,7 @@ class Document:
     def add_text(
         self,
         text: str,
-        font: Font = Font(font_name="Arial", height=12),
+        font: Font = Font(font_name="Arial", height=12, weight="normal"),
         page: Optional[int] = None,
         rect: Optional[Tuple[float, float, float, float]] = None,
         align: Align = Align.LEFT,
@@ -225,7 +227,7 @@ class Document:
         :return: the width of the text
         """
         root = Tk()  # Needed to estimate the width.
-        font_var = TkFont(family=font.font_name, size=font.height, weight="normal")
+        font_var = TkFont(family=font.font_name, size=font.height, weight=font.weight)
         width = font_var.measure(text) / 105
         root.destroy()  # Destroy the created window
         return width

--- a/pyrinter/printers/win_printer.py
+++ b/pyrinter/printers/win_printer.py
@@ -41,6 +41,7 @@ class Printer(AbsPrinter):
                     "height": int(
                         Printer.__inch_to_printer_size(data["font"].height / 72)
                     ),
+                    "weight": 700 if data["font"].weight == "bold" else 400,
                 }
             )
         )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pyrinter",
-    version="1.0.0",
+    version="1.0.1",
     packages=find_packages(include=["pyrinter", "pyrinter.*"]),
     author="Hod Vaknin",
     license="MIT",


### PR DESCRIPTION
Wanted to print a font with a bold weight, so added "bold" alongside "normal" for font weights to be printed.

These are the only font weights available for TKFont, which is used for measuring, so starting with just these values. The labels get converted to ints (400 and 700 respectively) when being used in win32ui, which requires ints.

It would be great to have this in the base repository, so let me know what you think.